### PR TITLE
Update jit_cc2ftr_train.py

### DIFF
--- a/JITLine_replication_package/CC2Vec_Modified/jit_cc2ftr_train.py
+++ b/JITLine_replication_package/CC2Vec_Modified/jit_cc2ftr_train.py
@@ -35,7 +35,6 @@ def train_model(data, params):
     
     optimizer = torch.optim.Adam(model.parameters(), lr=params.l2_reg_lambda)
     criterion = nn.BCEWithLogitsLoss()
-    batches = batches[:10]
     for epoch in range(1, params.num_epochs + 1):
         total_loss = 0
         for i, (batch) in enumerate(tqdm(batches)):


### PR DESCRIPTION
the number of batches trained on is limited to the first 10 batches. This seems to be a bug, as we would only train our embeddings on a very small subset (first 80 by default) of our dataset. The bug is also present in the original CC2Vec model.

What do you think?